### PR TITLE
Adding Wednesday due date

### DIFF
--- a/_data/readings.yml
+++ b/_data/readings.yml
@@ -39,3 +39,4 @@ opensource_guide:
   assignment: >
     Select *two* topics, read them, and be prepared to discuss how they apply to your Mini-Project 1, Mini-Project 2,
     or a project you've created or contributed in the past.
+  due: 2017-02-22


### PR DESCRIPTION
On the Readings page, there's no due date for the open source reading. I added a due date in the readings.yml file.